### PR TITLE
overall improvements

### DIFF
--- a/cfgtodict.py
+++ b/cfgtodict.py
@@ -1,4 +1,4 @@
-import configparser
+import configparser, re
 
 class ConfigToDictionary:
 
@@ -7,7 +7,8 @@ class ConfigToDictionary:
 
   def dict(self):
     # Parse config file
-    parser = configparser.ConfigParser()
+    parser = configparser.RawConfigParser(allow_no_value=True)
+    parser.optionxform=str
     parser.read(self.config)
 
     # Set config values on Dictionary
@@ -16,6 +17,16 @@ class ConfigToDictionary:
     for section in parser.sections():
       dict[section] = {}
       for option in parser.options(section):
-        dict[section][option] = parser.get(section, option)
-
+      	value = parser[section][option]
+      		if re.match(r'^[1-9]\d*$', value): # types: int
+      			dict[section][option] = parser.getint(section, option)
+      		elif re.match(r'^[+-]?([0-9]*[.])?[0-9]+', value): # types: float
+      			dict[section][option] = parser.getfloat(section, option)
+      		elif re.match(r'[True|False|None]', value): # types: bool
+      			dict[section][option] = parser.getboolean(section, option)
+      		else: # types: string
+      			dict[section][option] = parser.get(section, option)
+      	except Exception as e:
+      		print(f'Issue with value of "{option}" -> ', e)
+      		# dict[section][option] = parser.get(section, option)
     return dict


### PR DESCRIPTION
+ now value types for every item in dict will be kept intact as they were in the cfg file
+ key, value pairs will have the same capitalization as in the original cfg file now
+ keys with no values, will not be skipped anymore
+ using RawConfigParser instead to avoid interpolation errors in rare cases